### PR TITLE
Add admin and user email separation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ SMTP_USER=your-email@gmail.com
 SMTP_PASS=your-app-password
 
 # Notification Settings
-TO_EMAIL=recipient@example.com
+ADMIN_EMAILS=admin@example.com
+USER_EMAILS=user@example.com
 FROM_EMAIL=your-email@gmail.com
 
 # Cupos to Monitor (comma separated cupo IDs)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Create a `.env` file based on `.env.example` and configure the following variabl
 - `SMTP_SECURE`: Use SSL/TLS (default: false)
 - `SMTP_USER`: Your email address
 - `SMTP_PASS`: Your email password or app password
-- `TO_EMAIL`: Email address to receive notifications
+- `ADMIN_EMAILS`: Comma separated emails that will receive the startup notification
+- `USER_EMAILS`: Comma separated emails that will receive doctor status updates
 - `FROM_EMAIL`: Email address for sending notifications
 
 ### Gmail Setup

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -18,7 +18,9 @@ module.exports = {
       }
     },
     from: process.env.FROM_EMAIL,
-    to: process.env.TO_EMAIL ? 
-      process.env.TO_EMAIL.split(',').map(email => email.trim()) : []
+    admins: process.env.ADMIN_EMAILS ?
+      process.env.ADMIN_EMAILS.split(',').map(email => email.trim()) : [],
+    users: process.env.USER_EMAILS ?
+      process.env.USER_EMAILS.split(',').map(email => email.trim()) : []
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,8 @@ class DoctorChecker {
     }
 
     log.info(`Monitoreando: ${config.sergas.doctorsToMonitor.join(', ')} | Intervalo: ${config.sergas.checkInterval}min`);
-    log.info(`Emails: ${config.email.to.join(', ')}`);
+    log.info(`Admin emails: ${config.email.admins.join(', ')}`);
+    log.info(`User emails: ${config.email.users.join(', ')}`);
 
     // Send startup notification email
     const startupEmailSent = await this.emailService.sendStartupNotification(config.sergas.doctorsToMonitor);

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -10,7 +10,7 @@ class EmailService {
   async sendDoctorAvailableNotification(cupoInfo) {
     const mailOptions = {
       from: config.email.from,
-      to: config.email.to.join(', '), // Join all emails with comma
+      to: config.email.users.join(', '),
       subject: `🩺 CUPO DISPONIBLE: ${cupoInfo.name} - Estado: ${cupoInfo.estado}`,
       html: `
         <h2>¡El cupo ha cambiado de estado!</h2>
@@ -27,7 +27,7 @@ class EmailService {
 
     try {
       const info = await this.transporter.sendMail(mailOptions);
-      log.info(`Email sent successfully to: ${config.email.to.join(', ')}`);
+      log.info(`Email sent successfully to: ${config.email.users.join(', ')}`);
       return true;
     } catch (error) {
       log.error(`Failed to send email: ${error.message}`);
@@ -40,7 +40,7 @@ class EmailService {
     
     const mailOptions = {
       from: config.email.from,
-      to: config.email.to.join(', '),
+      to: config.email.admins.join(', '),
       subject: `🚀 Monitor SERGAS Iniciado - López Pan`,
       html: `
         <h2>🩺 Monitor SERGAS Activado</h2>
@@ -70,7 +70,7 @@ class EmailService {
 
     try {
       const info = await this.transporter.sendMail(mailOptions);
-      log.success(`Email de inicio enviado correctamente a: ${config.email.to.join(', ')}`);
+      log.success(`Email de inicio enviado correctamente a: ${config.email.admins.join(', ')}`);
       return true;
     } catch (error) {
       log.error(`Error al enviar email de inicio: ${error.message}`);

--- a/test/emailService.test.js
+++ b/test/emailService.test.js
@@ -17,7 +17,8 @@ jest.mock('../src/config/config', () => ({
   email: {
     smtp: {},
     from: 'from@test.com',
-    to: ['to1@test.com', 'to2@test.com']
+    users: ['user1@test.com', 'user2@test.com'],
+    admins: ['admin@test.com']
   }
 }));
 
@@ -42,7 +43,7 @@ describe('EmailService', () => {
     expect(sendMailMock).toHaveBeenCalled();
     expect(sendMailMock.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        to: 'to1@test.com, to2@test.com',
+        to: 'user1@test.com, user2@test.com',
         from: 'from@test.com'
       })
     );


### PR DESCRIPTION
## Summary
- split recipient lists into admins and users
- notify admins on startup and users on doctor status changes
- document new environment variables
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fef88625c832e9dc0585a83539b21